### PR TITLE
header: fix hashbang

### DIFF
--- a/header
+++ b/header
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 for i in $(find -name "*.[hc]")
 do
 	exec > tmp


### PR DESCRIPTION
Little fix.

Essential to make it work in non FHS distros such as Android Termux, NixOS, GoboLinux and others.

Signed-off-by: lucasew <lucas59356@gmail.com>
