### PR TITLE
fix: using the dark color for the bars

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -283,8 +283,8 @@ static void set_format(scanner_t* scanner, int ecl, byte mask)
 
 void qrc_encode(scanner_t* scanner, const char* data)
 {
-	char *black_block_char = scanner->use_netpbm ? "1 " : "██";
-	char *white_block_char = scanner->use_netpbm ? "0 " : "  ";
+	char *black_block_char = scanner->use_netpbm ? "1 " : "  ";
+	char *white_block_char = scanner->use_netpbm ? "0 " : "██";
 	// generate bit stream
 	stream_t stream;
 	stream.a = 0;


### PR DESCRIPTION
**fix: encoder/terminal: swap symbol colors, readers read more easily when the foreground is the dark color**

cc @qsantos 